### PR TITLE
fix: exclude /homepage from sitemap

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -31,7 +31,14 @@ module.exports = {
     },
     `gatsby-transformer-remark`,
     `gatsby-plugin-react-helmet`,
-    `gatsby-plugin-sitemap`,
+    {
+      resolve: `gatsby-plugin-sitemap`,
+      options: {
+        exclude: [
+          `/homepage`,
+        ]
+      }
+    },
     {
       resolve: `gatsby-plugin-google-tagmanager`,
       options: {


### PR DESCRIPTION
/homepage should be hidden from the world till it's ready
and shouldn't be indexed