### PR TITLE
Fix: header should be overlapped with footer

### DIFF
--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 import styled from 'styled-components'
 import Logo from '../Logo'
 import MainMenuWrapper from '../MainMenuWrapper'
-import { colors, displayDimensions, sizes } from '../../theme'
+import { colors, displayDimensions, sizes, zIndexes } from '../../theme'
 
 interface HeaderProps {
   siteTitle: string
@@ -18,6 +18,7 @@ const StyledHeaderWrapper = styled.div`
   position: fixed;
   top: 0;
   left: 0;
+  z-index: ${zIndexes.mainHeader};
   justify-content: space-between;
   background: ${colors.background};
 

--- a/src/components/Header/__snapshots__/Header.spec.tsx.snap
+++ b/src/components/Header/__snapshots__/Header.spec.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Header component renders correctly 1`] = `
 <div
-  className="sc-ifAKCX jOabxG"
+  className="sc-ifAKCX cNOviL"
 >
   <a
     aria-current="page"

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -3,5 +3,6 @@ import { transitions } from './transitions'
 import { displayDimensions } from './displayDimensions'
 import { sizes } from './sizes'
 import { typography } from './typography'
+import { zIndexes } from './zIndexes'
 
-export { colors, transitions, displayDimensions, sizes, typography }
+export { colors, transitions, displayDimensions, sizes, typography, zIndexes }

--- a/src/theme/zIndexes.ts
+++ b/src/theme/zIndexes.ts
@@ -1,0 +1,5 @@
+const basicZIndex = 100
+
+export const zIndexes = {
+  mainHeader: basicZIndex,
+}


### PR DESCRIPTION
Fixing header z-index to always be on top - on mobile it was overlapping the footer form.