### PR TITLE
feat: structured data types

### DIFF
--- a/content/blog/sample-post.md
+++ b/content/blog/sample-post.md
@@ -1,7 +1,7 @@
 ---
 title: Sample post
 date: 2018-11-17
-authors: [piotr.kwiecinski]
+author: Piotr Kwiecinski
 tags: [sample]
 ---
 

--- a/content/blog/sample-post.md
+++ b/content/blog/sample-post.md
@@ -1,7 +1,7 @@
 ---
 title: Sample post
 date: 2018-11-17
-author: Piotr Kwiecinski
+authors: [piotr-kwiecinski]
 tags: [sample]
 ---
 

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -9,6 +9,9 @@ module.exports = {
     siteUrl: config.siteUrl,
     title: `Codemanufacture - AWS and Magento Consultancy`,
   },
+  mapping: {
+    'MarkdownRemark.frontmatter.authors': 'AuthorJson',
+  },
   plugins: [
     `gatsby-transformer-json`,
     {

--- a/src/components/BlogPost/BlogPost.tsx
+++ b/src/components/BlogPost/BlogPost.tsx
@@ -66,7 +66,7 @@ const createAuthorData = (authors?: AuthorJson[]) => {
 
     return `{
       "@type": "Person",
-      "image": "${author.avatar}",
+      "image": "${author.avatar ? author.avatar.relativePath : ''}",
       "name": "${author.name}",
       "description": "${author.bio}",
       "sameAs": [

--- a/src/components/BlogPost/BlogPost.tsx
+++ b/src/components/BlogPost/BlogPost.tsx
@@ -56,7 +56,7 @@ interface BlogPostHelmetProps {
 }
 
 const createAuthorData = (authors?: AuthorJson[]) => {
-  if (!authors) {
+  if (!authors || !authors.length) {
     return false
   }
 

--- a/src/components/BlogPost/BlogPost.tsx
+++ b/src/components/BlogPost/BlogPost.tsx
@@ -40,17 +40,54 @@ const StyledPageWrapper = styled.div`
     font-size: 18px;
   }
 `
+interface FrontmatterInterface {
+  author?: string
+  date?: string
+  title?: string
+  tags?: string[]
+}
 
 interface BlogPostProps {
   title: string
   html: string
+  frontmatter: FrontmatterInterface
 }
 
-const BlogPost: React.FunctionComponent<BlogPostProps> = ({ title, html }) => {
+interface BlogPostHelmetProps {
+  frontmatter: FrontmatterInterface
+}
+
+const BlogPostHelmet: React.FunctionComponent<BlogPostHelmetProps> = props => {
+  const data = props.frontmatter
+
+  return (
+    <Helmet title={data.title}>
+      <script type="application/ld+json">
+        {`
+        {
+          "@context: "http://schema.org/",
+          "@type": "BlogPosting",
+          "name": "${data.title}",
+          "author": "${data.author}",
+          "date": "${data.date}",
+          "keywords": "${data.tags}",
+          "content"
+        }
+        `}
+      </script>
+    </Helmet>
+  )
+}
+
+const BlogPost: React.FunctionComponent<BlogPostProps> = ({
+  frontmatter,
+  title,
+  html,
+}) => {
   return (
     <Layout>
       <StyledPageWrapper>
-        <Helmet title={title} />
+        <BlogPostHelmet frontmatter={frontmatter} />
         <h1>{title}</h1>
         <div dangerouslySetInnerHTML={{ __html: html }} />
       </StyledPageWrapper>

--- a/src/components/BlogPost/BlogPost.tsx
+++ b/src/components/BlogPost/BlogPost.tsx
@@ -3,6 +3,7 @@ import Helmet from 'react-helmet'
 import styled from 'styled-components'
 import Layout from '../Layout'
 import { colors } from '../../theme'
+import { Frontmatter_2 } from '../../graphql-types'
 
 const StyledPageWrapper = styled.div`
   margin: 0 auto;
@@ -40,38 +41,38 @@ const StyledPageWrapper = styled.div`
     font-size: 18px;
   }
 `
-interface FrontmatterInterface {
-  author?: string
-  date?: string
-  title?: string
-  tags?: string[]
-}
 
 interface BlogPostProps {
+  excerpt: string
   title: string
   html: string
-  frontmatter: FrontmatterInterface
+  frontmatter: Frontmatter_2
 }
 
 interface BlogPostHelmetProps {
-  frontmatter: FrontmatterInterface
+  excerpt: string
+  frontmatter: Frontmatter_2
+  html: string
 }
 
 const BlogPostHelmet: React.FunctionComponent<BlogPostHelmetProps> = props => {
   const data = props.frontmatter
 
+  // TODO - add proper handling of multiple authors
+
   return (
-    <Helmet title={data.title}>
+    <Helmet title={data.title || ''}>
       <script type="application/ld+json">
         {`
         {
           "@context: "http://schema.org/",
           "@type": "BlogPosting",
           "name": "${data.title}",
-          "author": "${data.author}",
+          "author": "${data.authors}",
           "date": "${data.date}",
           "keywords": "${data.tags}",
-          "content"
+          "text": "${props.excerpt}",
+          "articleBody": "${props.html}",
         }
         `}
       </script>
@@ -80,6 +81,7 @@ const BlogPostHelmet: React.FunctionComponent<BlogPostHelmetProps> = props => {
 }
 
 const BlogPost: React.FunctionComponent<BlogPostProps> = ({
+  excerpt,
   frontmatter,
   title,
   html,
@@ -87,7 +89,11 @@ const BlogPost: React.FunctionComponent<BlogPostProps> = ({
   return (
     <Layout>
       <StyledPageWrapper>
-        <BlogPostHelmet frontmatter={frontmatter} />
+        <BlogPostHelmet
+          frontmatter={frontmatter}
+          excerpt={excerpt}
+          html={html}
+        />
         <h1>{title}</h1>
         <div dangerouslySetInnerHTML={{ __html: html }} />
       </StyledPageWrapper>

--- a/src/components/BlogPost/BlogPost.tsx
+++ b/src/components/BlogPost/BlogPost.tsx
@@ -3,7 +3,7 @@ import Helmet from 'react-helmet'
 import styled from 'styled-components'
 import Layout from '../Layout'
 import { colors } from '../../theme'
-import { Frontmatter_2 } from '../../graphql-types'
+import { Frontmatter_2, AuthorJson } from '../../graphql-types'
 
 const StyledPageWrapper = styled.div`
   margin: 0 auto;
@@ -55,10 +55,31 @@ interface BlogPostHelmetProps {
   html: string
 }
 
+const createAuthorData = (authors?: AuthorJson[]) => {
+  if (!authors) {
+    return false
+  }
+
+  return authors.map((author: AuthorJson) => {
+    const githubNick = author.github || ''
+    const twitterNick = author.github || ''
+
+    return `{
+      "@type": "Person",
+      "image": "${author.avatar}",
+      "name": "${author.name}",
+      "description": "${author.bio}",
+      "sameAs": [
+        "http://github.com/${githubNick.substring(1)}",
+        "http://twitter.com/${twitterNick.substring(1)}",
+      ]
+     },`
+  })
+}
+
 const BlogPostHelmet: React.FunctionComponent<BlogPostHelmetProps> = props => {
   const data = props.frontmatter
-
-  // TODO - add proper handling of multiple authors
+  const authors = data.authors ? data.authors : []
 
   return (
     <Helmet title={data.title || ''}>
@@ -68,7 +89,7 @@ const BlogPostHelmet: React.FunctionComponent<BlogPostHelmetProps> = props => {
           "@context: "http://schema.org/",
           "@type": "BlogPosting",
           "name": "${data.title}",
-          "author": "${data.authors}",
+          "author": [${createAuthorData(authors)}],
           "date": "${data.date}",
           "keywords": "${data.tags}",
           "text": "${props.excerpt}",

--- a/src/graphql-types.d.ts
+++ b/src/graphql-types.d.ts
@@ -8444,7 +8444,7 @@ export interface Frontmatter_2 {
 
   date?: Maybe<Date>
 
-  authors?: Maybe<(Maybe<string>)[]>
+  authors?: Maybe<AuthorJson[]>
 
   tags?: Maybe<(Maybe<string>)[]>
 

--- a/src/templates/PostTemplate.tsx
+++ b/src/templates/PostTemplate.tsx
@@ -34,7 +34,14 @@ export const postQuery = graphql`
       frontmatter {
         title
         date(formatString: "YYYY-MM-DD")
-        authors
+        authors {
+          id
+          name
+          avatar
+          bio
+          twitter
+          github
+        }
         tags
       }
     }

--- a/src/templates/PostTemplate.tsx
+++ b/src/templates/PostTemplate.tsx
@@ -37,7 +37,10 @@ export const postQuery = graphql`
         authors {
           id
           name
-          avatar
+          avatar {
+            id
+            relativePath
+          }
           bio
           twitter
           github

--- a/src/templates/PostTemplate.tsx
+++ b/src/templates/PostTemplate.tsx
@@ -10,9 +10,9 @@ interface PostTemplateProps {
 const PostTemplate: React.FunctionComponent<PostTemplateProps> = ({ data }) => {
   const frontmatter =
     (data && data.markdownRemark && data.markdownRemark.frontmatter) || {}
-  const title = frontmatter.title || ''
+  const title = frontmatter.title ? frontmatter.title : ''
   const html = (data && data.markdownRemark && data.markdownRemark.html) || ''
-  return <BlogPost html={html} title={title} />
+  return <BlogPost html={html} title={title} frontmatter={frontmatter} />
 }
 
 export default PostTemplate
@@ -23,6 +23,9 @@ export const postQuery = graphql`
       html
       frontmatter {
         title
+        date(formatString: "YYYY-MM-DD")
+        author
+        tags
       }
     }
   }

--- a/src/templates/PostTemplate.tsx
+++ b/src/templates/PostTemplate.tsx
@@ -12,7 +12,16 @@ const PostTemplate: React.FunctionComponent<PostTemplateProps> = ({ data }) => {
     (data && data.markdownRemark && data.markdownRemark.frontmatter) || {}
   const title = frontmatter.title ? frontmatter.title : ''
   const html = (data && data.markdownRemark && data.markdownRemark.html) || ''
-  return <BlogPost html={html} title={title} frontmatter={frontmatter} />
+  const excerpt =
+    (data && data.markdownRemark && data.markdownRemark.excerpt) || ''
+  return (
+    <BlogPost
+      html={html}
+      title={title}
+      excerpt={excerpt}
+      frontmatter={frontmatter}
+    />
+  )
 }
 
 export default PostTemplate
@@ -21,10 +30,11 @@ export const postQuery = graphql`
   query($slug: String!) {
     markdownRemark(fields: { slug: { eq: $slug } }) {
       html
+      excerpt
       frontmatter {
         title
         date(formatString: "YYYY-MM-DD")
-        author
+        authors
         tags
       }
     }


### PR DESCRIPTION
Added structured data types for BlogPost component, i.e.:
"@context: "http://schema.org/",
"@type": "BlogPosting",
"name": "${data.title}",
"authors": "${data.author}",
"date": "${data.date}",
"keywords": "${data.tags}",
"text": "${props.excerpt}",
"articleBody": "${props.html}"
