### PR TITLE
chore: update Node.js version to 24

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '24'
           cache: 'npm'
 
       - name: Install dependencies

--- a/flake.nix
+++ b/flake.nix
@@ -34,7 +34,7 @@
 
             nativeBuildInputs = with pkgs; [
               hugo
-              nodejs_22
+              nodejs_24
               nodePackages.npm
             ];
 
@@ -68,7 +68,7 @@
           devShells.default = pkgs.mkShellNoCC {
             nativeBuildInputs = [
               pkgs.hugo
-              pkgs.nodejs_22
+              pkgs.nodejs_24
               pkgs.awscli2
             ];
 


### PR DESCRIPTION
## Summary
- Update Node.js from version 22 to 24 in GitHub Actions CI workflow
- Update Node.js from version 22 to 24 in Nix flake (both build and dev environments)

## Test plan
- [ ] Verify CI workflow runs successfully with Node 24
- [ ] Verify Nix development shell works with Node 24

🤖 Generated with [Claude Code](https://claude.com/claude-code)