### PR TITLE
chore: migrate prettier to treefmt-nix

### DIFF
--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -1,0 +1,21 @@
+name: Format Check
+
+on:
+  pull_request:
+    branches: [master]
+
+jobs:
+  format-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@main
+
+      - name: Setup Nix cache
+        uses: DeterminateSystems/magic-nix-cache-action@main
+
+      - name: Check formatting
+        run: nix fmt -- --fail-on-change

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,4 +1,0 @@
-public
-resources
-package.json
-package-lock.json

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,6 +1,0 @@
-{
-  "semi": false,
-  "singleQuote": true,
-  "trailingComma": "es5",
-  "arrowParens": "avoid"
-}

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1,4 +1,4 @@
-@import "tailwindcss";
+@import 'tailwindcss';
 
 @theme {
   /* Brand Colors */
@@ -11,7 +11,7 @@
   --color-sky-600: #1a7aad;
 
   /* Typography */
-  --font-family-sans: "Montserrat", ui-sans-serif, system-ui, sans-serif;
+  --font-family-sans: 'Montserrat', ui-sans-serif, system-ui, sans-serif;
 }
 
 @plugin "@tailwindcss/typography";

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,65 +1,67 @@
 // Mobile menu toggle
-document.addEventListener('DOMContentLoaded', function() {
-  const menuButton = document.getElementById('mobile-menu-button');
-  const menuCloseButton = document.getElementById('mobile-menu-close');
-  const mobileMenu = document.getElementById('mobile-menu');
-  const openIcon = document.getElementById('menu-icon-open');
-  const closeIcon = document.getElementById('menu-icon-close');
+document.addEventListener('DOMContentLoaded', function () {
+  const menuButton = document.getElementById('mobile-menu-button')
+  const menuCloseButton = document.getElementById('mobile-menu-close')
+  const mobileMenu = document.getElementById('mobile-menu')
+  const openIcon = document.getElementById('menu-icon-open')
+  const closeIcon = document.getElementById('menu-icon-close')
 
   function openMenu() {
-    menuButton.setAttribute('aria-expanded', 'true');
-    mobileMenu.classList.remove('hidden');
-    openIcon.classList.add('hidden');
-    closeIcon.classList.remove('hidden');
+    menuButton.setAttribute('aria-expanded', 'true')
+    mobileMenu.classList.remove('hidden')
+    openIcon.classList.add('hidden')
+    closeIcon.classList.remove('hidden')
   }
 
   function closeMenu() {
-    menuButton.setAttribute('aria-expanded', 'false');
-    mobileMenu.classList.add('hidden');
-    openIcon.classList.remove('hidden');
-    closeIcon.classList.add('hidden');
+    menuButton.setAttribute('aria-expanded', 'false')
+    mobileMenu.classList.add('hidden')
+    openIcon.classList.remove('hidden')
+    closeIcon.classList.add('hidden')
   }
 
   if (menuButton && mobileMenu) {
-    menuButton.addEventListener('click', function() {
-      const isExpanded = menuButton.getAttribute('aria-expanded') === 'true';
+    menuButton.addEventListener('click', function () {
+      const isExpanded = menuButton.getAttribute('aria-expanded') === 'true'
       if (isExpanded) {
-        closeMenu();
+        closeMenu()
       } else {
-        openMenu();
+        openMenu()
       }
-    });
+    })
   }
 
   if (menuCloseButton) {
-    menuCloseButton.addEventListener('click', closeMenu);
+    menuCloseButton.addEventListener('click', closeMenu)
   }
 
   // Close mobile menu when clicking on a link
-  const menuLinks = mobileMenu?.querySelectorAll('a');
-  menuLinks?.forEach(function(link) {
-    link.addEventListener('click', closeMenu);
-  });
-});
+  const menuLinks = mobileMenu?.querySelectorAll('a')
+  menuLinks?.forEach(function (link) {
+    link.addEventListener('click', closeMenu)
+  })
+})
 
 // Go to top button
-document.addEventListener('DOMContentLoaded', function() {
-  const goToTopButton = document.createElement('button');
-  goToTopButton.id = 'go-to-top';
-  goToTopButton.className = 'fixed bottom-8 right-8 z-50 hidden p-3 bg-sky-500 text-white rounded-full shadow-lg hover:bg-sky-600 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-2 transition-opacity';
-  goToTopButton.setAttribute('aria-label', 'Go to top');
-  goToTopButton.innerHTML = '<svg class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M4.5 15.75l7.5-7.5 7.5 7.5" /></svg>';
-  document.body.appendChild(goToTopButton);
+document.addEventListener('DOMContentLoaded', function () {
+  const goToTopButton = document.createElement('button')
+  goToTopButton.id = 'go-to-top'
+  goToTopButton.className =
+    'fixed bottom-8 right-8 z-50 hidden p-3 bg-sky-500 text-white rounded-full shadow-lg hover:bg-sky-600 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-2 transition-opacity'
+  goToTopButton.setAttribute('aria-label', 'Go to top')
+  goToTopButton.innerHTML =
+    '<svg class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M4.5 15.75l7.5-7.5 7.5 7.5" /></svg>'
+  document.body.appendChild(goToTopButton)
 
-  window.addEventListener('scroll', function() {
+  window.addEventListener('scroll', function () {
     if (window.scrollY > 300) {
-      goToTopButton.classList.remove('hidden');
+      goToTopButton.classList.remove('hidden')
     } else {
-      goToTopButton.classList.add('hidden');
+      goToTopButton.classList.add('hidden')
     }
-  });
+  })
 
-  goToTopButton.addEventListener('click', function() {
-    window.scrollTo({ top: 0, behavior: 'smooth' });
-  });
-});
+  goToTopButton.addEventListener('click', function () {
+    window.scrollTo({ top: 0, behavior: 'smooth' })
+  })
+})

--- a/flake.nix
+++ b/flake.nix
@@ -59,10 +59,31 @@
               "*.gitignore"
               ".envrc"
               "LICENSE"
+              "public/*"
+              "resources/*"
+              "package.json"
+              "package-lock.json"
             ];
 
             programs.nixfmt.enable = true;
-            programs.prettier.enable = true;
+            programs.prettier = {
+              enable = true;
+              settings = {
+                semi = false;
+                singleQuote = true;
+                trailingComma = "es5";
+                arrowParens = "avoid";
+                plugins = [
+                  "${pkgs.prettier-plugin-go-template}/lib/node_modules/prettier-plugin-go-template/lib/index.js"
+                ];
+                overrides = [
+                  {
+                    files = [ "layouts/**/*.html" ];
+                    options.parser = "go-template";
+                  }
+                ];
+              };
+            };
           };
 
           devShells.default = pkgs.mkShellNoCC {

--- a/layouts/404.html
+++ b/layouts/404.html
@@ -2,10 +2,19 @@
 <section class="min-h-[60vh] flex items-center justify-center">
   <div class="mx-auto max-w-7xl px-6 py-32 text-center sm:py-40 lg:px-8">
     <p class="text-base font-semibold leading-8 text-sky-600">404</p>
-    <h1 class="mt-4 text-3xl font-bold tracking-tight text-gray-900 sm:text-5xl">Page not found</h1>
-    <p class="mt-4 text-base text-gray-600 sm:mt-6">Sorry, we couldn't find the page you're looking for.</p>
+    <h1
+      class="mt-4 text-3xl font-bold tracking-tight text-gray-900 sm:text-5xl"
+    >
+      Page not found
+    </h1>
+    <p class="mt-4 text-base text-gray-600 sm:mt-6">
+      Sorry, we couldn't find the page you're looking for.
+    </p>
     <div class="mt-10 flex justify-center">
-      <a href="/" class="text-sm font-semibold leading-6 text-sky-600 hover:text-sky-500">
+      <a
+        href="/"
+        class="text-sm font-semibold leading-6 text-sky-600 hover:text-sky-500"
+      >
         <span aria-hidden="true">&larr;</span> Go back home
       </a>
     </div>

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -1,15 +1,13 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     {{- partial "head.html" . -}}
   </head>
   <body class="font-sans antialiased text-gray-900">
     {{- partial "header.html" . -}}
-    <main>
-      {{- block "main" . }}{{- end }}
-    </main>
-    {{- partial "footer.html" . -}}
-    {{- $js := resources.Get "js/main.js" | minify -}}
+    <main>{{- block "main" . }}{{- end }}</main>
+    {{- partial "footer.html" . -}} {{- $js := resources.Get "js/main.js" |
+    minify -}}
     <script src="{{ $js.Permalink }}"></script>
   </body>
 </html>

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -2,15 +2,17 @@
 <section class="py-16 lg:py-24">
   <div class="mx-auto max-w-7xl px-6 lg:px-8">
     <header class="mx-auto max-w-2xl text-center mb-16">
-      <h1 class="text-3xl font-bold tracking-tight text-gray-900 sm:text-4xl">{{ .Title }}</h1>
+      <h1 class="text-3xl font-bold tracking-tight text-gray-900 sm:text-4xl">
+        {{ .Title }}
+      </h1>
       {{ with .Description }}
       <p class="mt-2 text-lg leading-8 text-gray-600">{{ . }}</p>
       {{ end }}
     </header>
-    <div class="mx-auto grid max-w-2xl grid-cols-1 gap-x-8 gap-y-20 lg:mx-0 lg:max-w-none lg:grid-cols-3">
-      {{ range .Pages }}
-        {{ partial "blog-post-card.html" . }}
-      {{ end }}
+    <div
+      class="mx-auto grid max-w-2xl grid-cols-1 gap-x-8 gap-y-20 lg:mx-0 lg:max-w-none lg:grid-cols-3"
+    >
+      {{ range .Pages }} {{ partial "blog-post-card.html" . }} {{ end }}
     </div>
   </div>
 </section>

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -2,11 +2,11 @@
 <article class="py-16 lg:py-24">
   <div class="mx-auto max-w-3xl px-6 lg:px-8">
     <header class="mb-10">
-      <h1 class="text-3xl font-bold tracking-tight text-gray-900 sm:text-4xl">{{ .Title }}</h1>
+      <h1 class="text-3xl font-bold tracking-tight text-gray-900 sm:text-4xl">
+        {{ .Title }}
+      </h1>
     </header>
-    <div class="prose prose-lg prose-sky max-w-none">
-      {{ .Content }}
-    </div>
+    <div class="prose prose-lg prose-sky max-w-none">{{ .Content }}</div>
   </div>
 </article>
 {{ end }}

--- a/layouts/blog/list.html
+++ b/layouts/blog/list.html
@@ -5,15 +5,15 @@
   </div>
   <div class="relative mx-auto max-w-7xl">
     <div class="text-center">
-      <h1 class="text-3xl font-bold tracking-tight text-gray-900 sm:text-4xl">Blog</h1>
+      <h1 class="text-3xl font-bold tracking-tight text-gray-900 sm:text-4xl">
+        Blog
+      </h1>
       <p class="mt-2 text-lg leading-8 text-gray-600">
         Insights and best practices for Magento development.
       </p>
     </div>
     <div class="mx-auto mt-12 grid max-w-lg gap-5 lg:max-w-none lg:grid-cols-3">
-      {{ range .Pages }}
-        {{ partial "blog-post-card.html" . }}
-      {{ end }}
+      {{ range .Pages }} {{ partial "blog-post-card.html" . }} {{ end }}
     </div>
   </div>
 </section>

--- a/layouts/blog/single.html
+++ b/layouts/blog/single.html
@@ -1,73 +1,78 @@
 {{ define "main" }}
 <!-- JSON-LD Schema -->
 <script type="application/ld+json">
-{
-  "@context": "https://schema.org",
-  "@type": "BlogPosting",
-  "headline": {{ .Title | jsonify }},
-  "datePublished": "{{ .Date.Format "2006-01-02T15:04:05Z07:00" }}",
-  {{ with .Lastmod }}"dateModified": "{{ .Format "2006-01-02T15:04:05Z07:00" }}",{{ end }}
-  "url": "{{ .Permalink }}",
-  {{ with .Params.authors }}
-  {{ $authorId := index . 0 }}
-  {{ $authors := $.Site.Data.authors }}
-  {{ $author := index $authors $authorId }}
-  {{ if $author }}
-  "author": {
-    "@type": "Person",
-    "name": {{ $author.name | jsonify }}
-  },
-  {{ end }}
-  {{ end }}
-  "publisher": {
-    "@type": "Organization",
-    "name": "Codemanufacture",
-    "url": "{{ .Site.BaseURL }}"
-  },
-  {{ with .Params.tags }}"keywords": {{ . | jsonify }},{{ end }}
-  "articleBody": {{ .Plain | jsonify }}
-}
+  {
+    "@context": "https://schema.org",
+    "@type": "BlogPosting",
+    "headline": {{ .Title | jsonify }},
+    "datePublished": "{{ .Date.Format "2006-01-02T15:04:05Z07:00" }}",
+    {{ with .Lastmod }}"dateModified": "{{ .Format "2006-01-02T15:04:05Z07:00" }}",{{ end }}
+    "url": "{{ .Permalink }}",
+    {{ with .Params.authors }}
+    {{ $authorId := index . 0 }}
+    {{ $authors := $.Site.Data.authors }}
+    {{ $author := index $authors $authorId }}
+    {{ if $author }}
+    "author": {
+      "@type": "Person",
+      "name": {{ $author.name | jsonify }}
+    },
+    {{ end }}
+    {{ end }}
+    "publisher": {
+      "@type": "Organization",
+      "name": "Codemanufacture",
+      "url": "{{ .Site.BaseURL }}"
+    },
+    {{ with .Params.tags }}"keywords": {{ . | jsonify }},{{ end }}
+    "articleBody": {{ .Plain | jsonify }}
+  }
 </script>
 
 <article class="py-16 lg:py-24">
   <div class="mx-auto max-w-3xl px-6 lg:px-8">
     <header class="mb-10">
       <div class="flex items-center gap-x-4 text-xs mb-4">
-        <time datetime="{{ .Date.Format "2006-01-02" }}" class="text-gray-500">
+        <time datetime='{{ .Date.Format "2006-01-02" }}' class="text-gray-500">
           {{ .Date.Format "January 2, 2006" }}
         </time>
         {{ range .Params.tags }}
-        <span class="relative z-10 rounded-full bg-gray-50 px-3 py-1.5 font-medium text-gray-600">
+        <span
+          class="relative z-10 rounded-full bg-gray-50 px-3 py-1.5 font-medium text-gray-600"
+        >
           {{ . }}
         </span>
         {{ end }}
       </div>
-      <h1 class="text-3xl font-bold tracking-tight text-gray-900 sm:text-4xl">{{ .Title }}</h1>
+      <h1 class="text-3xl font-bold tracking-tight text-gray-900 sm:text-4xl">
+        {{ .Title }}
+      </h1>
       {{ with .Params.summary }}
       <p class="mt-4 text-xl text-gray-600">{{ . }}</p>
-      {{ end }}
-      {{ with .Params.authors }}
-      {{ $authorId := index . 0 }}
-      {{ $authors := $.Site.Data.authors }}
-      {{ $author := index $authors $authorId }}
-      {{ if $author }}
+      {{ end }} {{ with .Params.authors }} {{ $authorId := index . 0 }} {{
+      $authors := $.Site.Data.authors }} {{ $author := index $authors $authorId
+      }} {{ if $author }}
       <div class="mt-8 flex items-center gap-x-4 border-t border-gray-200 pt-8">
         {{ if $author.showAvatar }}
-        <img src="{{ $author.avatar }}" alt="{{ $author.name }}" class="h-12 w-12 rounded-full bg-gray-100">
+        <img
+          src="{{ $author.avatar }}"
+          alt="{{ $author.name }}"
+          class="h-12 w-12 rounded-full bg-gray-100"
+        />
         {{ end }}
         <div class="text-sm leading-6">
           <p class="font-semibold text-gray-900">{{ $author.name }}</p>
           <p class="text-gray-600">{{ $author.role }}</p>
         </div>
       </div>
-      {{ end }}
-      {{ end }}
+      {{ end }} {{ end }}
     </header>
-    <div class="prose prose-lg prose-sky max-w-none">
-      {{ .Content }}
-    </div>
+    <div class="prose prose-lg prose-sky max-w-none">{{ .Content }}</div>
     <footer class="mt-16 border-t border-gray-200 pt-8">
-      <a href="/blog/" class="text-sm font-semibold text-sky-600 hover:text-sky-500">
+      <a
+        href="/blog/"
+        class="text-sm font-semibold text-sky-600 hover:text-sky-500"
+      >
         <span aria-hidden="true">&larr;</span> Back to all posts
       </a>
     </footer>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,7 +1,9 @@
 {{ define "main" }}
 <!-- Services Section -->
 <section id="services" class="relative bg-white py-14 sm:py-20 lg:py-24">
-  <div class="mx-auto max-w-md px-6 text-center sm:max-w-3xl lg:max-w-7xl lg:px-8">
+  <div
+    class="mx-auto max-w-md px-6 text-center sm:max-w-3xl lg:max-w-7xl lg:px-8"
+  >
     <h2 class="text-lg font-semibold text-sky-600">Services</h2>
     <p class="mt-2 text-3xl font-bold tracking-tight text-gray-900 sm:text-4xl">
       Manufacturing your success
@@ -13,25 +15,59 @@
           <div class="flow-root rounded-lg bg-gray-50 px-6 pb-8">
             <div class="-mt-6">
               <div>
-                <span class="inline-flex items-center justify-center rounded-xl bg-sky-500 p-3 shadow-lg">
+                <span
+                  class="inline-flex items-center justify-center rounded-xl bg-sky-500 p-3 shadow-lg"
+                >
                   <div class="h-8 w-8 text-white">
                     {{ if eq .icon "shopping-cart" }}
-                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
-                      <path stroke-linecap="round" stroke-linejoin="round" d="M2.25 3h1.386c.51 0 .955.343 1.087.835l.383 1.437M7.5 14.25a3 3 0 00-3 3h15.75m-12.75-3h11.218c1.121-2.3 2.1-4.684 2.924-7.138a60.114 60.114 0 00-16.536-1.84M7.5 14.25L5.106 5.272M6 20.25a.75.75 0 11-1.5 0 .75.75 0 011.5 0zm12.75 0a.75.75 0 11-1.5 0 .75.75 0 011.5 0z" />
+                    <svg
+                      xmlns="http://www.w3.org/2000/svg"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      stroke-width="1.5"
+                      stroke="currentColor"
+                    >
+                      <path
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        d="M2.25 3h1.386c.51 0 .955.343 1.087.835l.383 1.437M7.5 14.25a3 3 0 00-3 3h15.75m-12.75-3h11.218c1.121-2.3 2.1-4.684 2.924-7.138a60.114 60.114 0 00-16.536-1.84M7.5 14.25L5.106 5.272M6 20.25a.75.75 0 11-1.5 0 .75.75 0 011.5 0zm12.75 0a.75.75 0 11-1.5 0 .75.75 0 011.5 0z"
+                      />
                     </svg>
                     {{ else if eq .icon "wrench" }}
-                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
-                      <path stroke-linecap="round" stroke-linejoin="round" d="M11.42 15.17L17.25 21A2.652 2.652 0 0021 17.25l-5.877-5.877M11.42 15.17l2.496-3.03c.317-.384.74-.626 1.208-.766M11.42 15.17l-4.655 5.653a2.548 2.548 0 11-3.586-3.586l6.837-5.63m5.108-.233c.55-.164 1.163-.188 1.743-.14a4.5 4.5 0 004.486-6.336l-3.276 3.277a3.004 3.004 0 01-2.25-2.25l3.276-3.276a4.5 4.5 0 00-6.336 4.486c.091 1.076-.071 2.264-.904 2.95l-.102.085m-1.745 1.437L5.909 7.5H4.5L2.25 3.75l1.5-1.5L7.5 4.5v1.409l4.26 4.26m-1.745 1.437l1.745-1.437m6.615 8.206L15.75 15.75M4.867 19.125h.008v.008h-.008v-.008z" />
+                    <svg
+                      xmlns="http://www.w3.org/2000/svg"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      stroke-width="1.5"
+                      stroke="currentColor"
+                    >
+                      <path
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        d="M11.42 15.17L17.25 21A2.652 2.652 0 0021 17.25l-5.877-5.877M11.42 15.17l2.496-3.03c.317-.384.74-.626 1.208-.766M11.42 15.17l-4.655 5.653a2.548 2.548 0 11-3.586-3.586l6.837-5.63m5.108-.233c.55-.164 1.163-.188 1.743-.14a4.5 4.5 0 004.486-6.336l-3.276 3.277a3.004 3.004 0 01-2.25-2.25l3.276-3.276a4.5 4.5 0 00-6.336 4.486c.091 1.076-.071 2.264-.904 2.95l-.102.085m-1.745 1.437L5.909 7.5H4.5L2.25 3.75l1.5-1.5L7.5 4.5v1.409l4.26 4.26m-1.745 1.437l1.745-1.437m6.615 8.206L15.75 15.75M4.867 19.125h.008v.008h-.008v-.008z"
+                      />
                     </svg>
                     {{ else if eq .icon "code" }}
-                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
-                      <path stroke-linecap="round" stroke-linejoin="round" d="M17.25 6.75L22.5 12l-5.25 5.25m-10.5 0L1.5 12l5.25-5.25m7.5-3l-4.5 16.5" />
+                    <svg
+                      xmlns="http://www.w3.org/2000/svg"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      stroke-width="1.5"
+                      stroke="currentColor"
+                    >
+                      <path
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        d="M17.25 6.75L22.5 12l-5.25 5.25m-10.5 0L1.5 12l5.25-5.25m7.5-3l-4.5 16.5"
+                      />
                     </svg>
                     {{ end }}
                   </div>
                 </span>
               </div>
-              <h3 class="mt-8 text-lg font-semibold leading-8 tracking-tight text-gray-900">
+              <h3
+                class="mt-8 text-lg font-semibold leading-8 tracking-tight text-gray-900"
+              >
                 {{ .name }}
               </h3>
               <p class="mt-5 text-base leading-7 text-gray-600">
@@ -46,21 +82,24 @@
   </div>
 </section>
 
-{{ $posts := where .Site.RegularPages "Section" "blog" }}
-{{ $publishedPosts := where $posts ".Draft" false }}
-{{ if gt (len $publishedPosts) 0 }}
+{{ $posts := where .Site.RegularPages "Section" "blog" }} {{ $publishedPosts :=
+where $posts ".Draft" false }} {{ if gt (len $publishedPosts) 0 }}
 <!-- Blog Preview Section -->
-<section id="blog" class="relative bg-gray-50 px-6 pt-10 pb-16 lg:px-8 lg:pt-14 lg:pb-28">
+<section
+  id="blog"
+  class="relative bg-gray-50 px-6 pt-10 pb-16 lg:px-8 lg:pt-14 lg:pb-28"
+>
   <div class="absolute inset-0">
     <div class="h-1/3 bg-white sm:h-2/3"></div>
   </div>
   <div class="relative mx-auto max-w-7xl">
     <div class="text-center">
-      <h2 class="text-3xl font-bold tracking-tight text-gray-900 sm:text-4xl">From the blog</h2>
+      <h2 class="text-3xl font-bold tracking-tight text-gray-900 sm:text-4xl">
+        From the blog
+      </h2>
     </div>
     <div class="mx-auto mt-12 grid max-w-lg gap-5 lg:max-w-none lg:grid-cols-3">
-      {{ range first 3 $publishedPosts }}
-        {{ partial "blog-post-card.html" . }}
+      {{ range first 3 $publishedPosts }} {{ partial "blog-post-card.html" . }}
       {{ end }}
     </div>
   </div>
@@ -76,14 +115,26 @@
           Let's work together
         </h2>
         <p class="mt-3 text-lg leading-6 text-gray-500">
-          We'd love to hear from you! Send us a message using email or give us a call.
+          We'd love to hear from you! Send us a message using email or give us a
+          call.
         </p>
         <dl class="mt-8 text-base text-gray-500">
           <div class="mt-6">
             <dt class="sr-only">Phone number</dt>
             <dd class="flex">
-              <svg class="h-6 w-6 flex-shrink-0 text-gray-400" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
-                <path stroke-linecap="round" stroke-linejoin="round" d="M2.25 6.75c0 8.284 6.716 15 15 15h2.25a2.25 2.25 0 002.25-2.25v-1.372c0-.516-.351-.966-.852-1.091l-4.423-1.106c-.44-.11-.902.055-1.173.417l-.97 1.293c-.282.376-.769.542-1.21.38a12.035 12.035 0 01-7.143-7.143c-.162-.441.004-.928.38-1.21l1.293-.97c.363-.271.527-.734.417-1.173L6.963 3.102a1.125 1.125 0 00-1.091-.852H4.5A2.25 2.25 0 002.25 4.5v2.25z" />
+              <svg
+                class="h-6 w-6 flex-shrink-0 text-gray-400"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke-width="1.5"
+                stroke="currentColor"
+                aria-hidden="true"
+              >
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  d="M2.25 6.75c0 8.284 6.716 15 15 15h2.25a2.25 2.25 0 002.25-2.25v-1.372c0-.516-.351-.966-.852-1.091l-4.423-1.106c-.44-.11-.902.055-1.173.417l-.97 1.293c-.282.376-.769.542-1.21.38a12.035 12.035 0 01-7.143-7.143c-.162-.441.004-.928.38-1.21l1.293-.97c.363-.271.527-.734.417-1.173L6.963 3.102a1.125 1.125 0 00-1.091-.852H4.5A2.25 2.25 0 002.25 4.5v2.25z"
+                />
               </svg>
               <span class="ml-3">+39 345 523 5101</span>
             </dd>
@@ -91,11 +142,25 @@
           <div class="mt-3">
             <dt class="sr-only">Email</dt>
             <dd class="flex">
-              <svg class="h-6 w-6 flex-shrink-0 text-gray-400" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
-                <path stroke-linecap="round" stroke-linejoin="round" d="M21.75 6.75v10.5a2.25 2.25 0 01-2.25 2.25h-15a2.25 2.25 0 01-2.25-2.25V6.75m19.5 0A2.25 2.25 0 0019.5 4.5h-15a2.25 2.25 0 00-2.25 2.25m19.5 0v.243a2.25 2.25 0 01-1.07 1.916l-7.5 4.615a2.25 2.25 0 01-2.36 0L3.32 8.91a2.25 2.25 0 01-1.07-1.916V6.75" />
+              <svg
+                class="h-6 w-6 flex-shrink-0 text-gray-400"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke-width="1.5"
+                stroke="currentColor"
+                aria-hidden="true"
+              >
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  d="M21.75 6.75v10.5a2.25 2.25 0 01-2.25 2.25h-15a2.25 2.25 0 01-2.25-2.25V6.75m19.5 0A2.25 2.25 0 0019.5 4.5h-15a2.25 2.25 0 00-2.25 2.25m19.5 0v.243a2.25 2.25 0 01-1.07 1.916l-7.5 4.615a2.25 2.25 0 01-2.36 0L3.32 8.91a2.25 2.25 0 01-1.07-1.916V6.75"
+                />
               </svg>
               <span class="ml-3">
-                <a href="mailto:contact@codemanufacture.com" class="text-sky-600 hover:text-sky-500">
+                <a
+                  href="mailto:contact@codemanufacture.com"
+                  class="text-sky-600 hover:text-sky-500"
+                >
                   contact@codemanufacture.com
                 </a>
               </span>
@@ -116,16 +181,24 @@
           Meet our team
         </h2>
         <p class="text-xl text-gray-500">
-          A small team of seasoned Magento developers with over a decade of experience.
+          A small team of seasoned Magento developers with over a decade of
+          experience.
         </p>
       </div>
       <div class="lg:col-span-2 md:mt-12">
-        <ul role="list" class="space-y-12 sm:grid sm:grid-cols-2 sm:gap-12 sm:space-y-0 lg:gap-x-8">
+        <ul
+          role="list"
+          class="space-y-12 sm:grid sm:grid-cols-2 sm:gap-12 sm:space-y-0 lg:gap-x-8"
+        >
           {{ range $id, $person := .Site.Data.authors }}
           <li>
             <div class="flex items-center space-x-4 lg:space-x-6">
               {{ if $person.showAvatar }}
-              <img class="h-16 w-16 rounded-full lg:h-20 lg:w-20" src="{{ $person.avatar }}" alt="{{ $person.name }}">
+              <img
+                class="h-16 w-16 rounded-full lg:h-20 lg:w-20"
+                src="{{ $person.avatar }}"
+                alt="{{ $person.name }}"
+              />
               {{ end }}
               <div class="space-y-1 text-lg font-medium leading-6">
                 <h3>{{ $person.name }}</h3>
@@ -133,20 +206,45 @@
                 <ul role="list" class="flex space-x-5">
                   {{ with $person.twitter }}
                   <li>
-                    <a href="{{ . }}" class="text-gray-400 hover:text-gray-500" target="_blank" rel="noopener noreferrer">
+                    <a
+                      href="{{ . }}"
+                      class="text-gray-400 hover:text-gray-500"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
                       <span class="sr-only">Twitter</span>
-                      <svg class="h-5 w-5" aria-hidden="true" fill="currentColor" viewBox="0 0 20 20">
-                        <path d="M6.29 18.251c7.547 0 11.675-6.253 11.675-11.675 0-.178 0-.355-.012-.53A8.348 8.348 0 0020 3.92a8.19 8.19 0 01-2.357.646 4.118 4.118 0 001.804-2.27 8.224 8.224 0 01-2.605.996 4.107 4.107 0 00-6.993 3.743 11.65 11.65 0 01-8.457-4.287 4.106 4.106 0 001.27 5.477A4.073 4.073 0 01.8 7.713v.052a4.105 4.105 0 003.292 4.022 4.095 4.095 0 01-1.853.07 4.108 4.108 0 003.834 2.85A8.233 8.233 0 010 16.407a11.616 11.616 0 006.29 1.84" />
+                      <svg
+                        class="h-5 w-5"
+                        aria-hidden="true"
+                        fill="currentColor"
+                        viewBox="0 0 20 20"
+                      >
+                        <path
+                          d="M6.29 18.251c7.547 0 11.675-6.253 11.675-11.675 0-.178 0-.355-.012-.53A8.348 8.348 0 0020 3.92a8.19 8.19 0 01-2.357.646 4.118 4.118 0 001.804-2.27 8.224 8.224 0 01-2.605.996 4.107 4.107 0 00-6.993 3.743 11.65 11.65 0 01-8.457-4.287 4.106 4.106 0 001.27 5.477A4.073 4.073 0 01.8 7.713v.052a4.105 4.105 0 003.292 4.022 4.095 4.095 0 01-1.853.07 4.108 4.108 0 003.834 2.85A8.233 8.233 0 010 16.407a11.616 11.616 0 006.29 1.84"
+                        />
                       </svg>
                     </a>
                   </li>
-                  {{ end }}
-                  {{ with $person.linkedin }}
+                  {{ end }} {{ with $person.linkedin }}
                   <li>
-                    <a href="{{ . }}" class="text-gray-400 hover:text-gray-500" target="_blank" rel="noopener noreferrer">
+                    <a
+                      href="{{ . }}"
+                      class="text-gray-400 hover:text-gray-500"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
                       <span class="sr-only">LinkedIn</span>
-                      <svg class="h-5 w-5" aria-hidden="true" fill="currentColor" viewBox="0 0 20 20">
-                        <path fill-rule="evenodd" d="M16.338 16.338H13.67V12.16c0-.995-.017-2.277-1.387-2.277-1.39 0-1.601 1.086-1.601 2.207v4.248H8.014v-8.59h2.559v1.174h.037c.356-.675 1.227-1.387 2.526-1.387 2.703 0 3.203 1.778 3.203 4.092v4.711zM5.005 6.575a1.548 1.548 0 11-.003-3.096 1.548 1.548 0 01.003 3.096zm-1.337 9.763H6.34v-8.59H3.667v8.59zM17.668 1H2.328C1.595 1 1 1.581 1 2.298v15.403C1 18.418 1.595 19 2.328 19h15.34c.734 0 1.332-.582 1.332-1.299V2.298C19 1.581 18.402 1 17.668 1z" clip-rule="evenodd" />
+                      <svg
+                        class="h-5 w-5"
+                        aria-hidden="true"
+                        fill="currentColor"
+                        viewBox="0 0 20 20"
+                      >
+                        <path
+                          fill-rule="evenodd"
+                          d="M16.338 16.338H13.67V12.16c0-.995-.017-2.277-1.387-2.277-1.39 0-1.601 1.086-1.601 2.207v4.248H8.014v-8.59h2.559v1.174h.037c.356-.675 1.227-1.387 2.526-1.387 2.703 0 3.203 1.778 3.203 4.092v4.711zM5.005 6.575a1.548 1.548 0 11-.003-3.096 1.548 1.548 0 01.003 3.096zm-1.337 9.763H6.34v-8.59H3.667v8.59zM17.668 1H2.328C1.595 1 1 1.581 1 2.298v15.403C1 18.418 1.595 19 2.328 19h15.34c.734 0 1.332-.582 1.332-1.299V2.298C19 1.581 18.402 1 17.668 1z"
+                          clip-rule="evenodd"
+                        />
                       </svg>
                     </a>
                   </li>

--- a/layouts/partials/blog-post-card.html
+++ b/layouts/partials/blog-post-card.html
@@ -1,4 +1,6 @@
-<article class="flex flex-col overflow-hidden rounded-lg shadow-lg border-t-4 border-sky-500">
+<article
+  class="flex flex-col overflow-hidden rounded-lg shadow-lg border-t-4 border-sky-500"
+>
   <div class="flex flex-1 flex-col justify-between bg-white p-6">
     <div class="flex-1">
       {{ if .Draft }}
@@ -18,31 +20,36 @@
       {{ end }}
     </div>
     <div class="mt-6 flex items-center">
-      {{ with .Params.authors }}
-      {{ $authorId := index . 0 }}
-      {{ $authors := $.Site.Data.authors }}
-      {{ $author := index $authors $authorId }}
-      {{ if $author }}
+      {{ with .Params.authors }} {{ $authorId := index . 0 }} {{ $authors :=
+      $.Site.Data.authors }} {{ $author := index $authors $authorId }} {{ if
+      $author }}
       <div class="flex-shrink-0">
         {{ if $author.showAvatar }}
         <span class="sr-only">{{ $author.name }}</span>
-        <img class="h-10 w-10 rounded-full" src="{{ $author.avatar }}" alt="{{ $author.name }}">
+        <img
+          class="h-10 w-10 rounded-full"
+          src="{{ $author.avatar }}"
+          alt="{{ $author.name }}"
+        />
         {{ end }}
       </div>
       <div class="ml-3">
         <p class="text-sm font-medium text-gray-900">{{ $author.name }}</p>
         <div class="flex space-x-1 text-sm text-gray-500">
           {{ if not $.Draft }}
-          <time datetime="{{ $.Date.Format "2006-01-02" }}">{{ $.Date.Format "Jan 2, 2006" }}</time>
+          <time datetime='{{ $.Date.Format "2006-01-02" }}'
+            >{{ $.Date.Format "Jan 2, 2006" }}</time
+          >
           <span aria-hidden="true">&middot;</span>
-          <span>{{ math.Round (div (countwords $.Plain) 200.0) }} min read</span>
+          <span
+            >{{ math.Round (div (countwords $.Plain) 200.0) }} min read</span
+          >
           {{ else }}
           <span>Coming soon</span>
           {{ end }}
         </div>
       </div>
-      {{ end }}
-      {{ end }}
+      {{ end }} {{ end }}
     </div>
   </div>
 </article>

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,47 +1,107 @@
 <footer class="bg-neutral-900" aria-labelledby="footer-heading">
   <div class="mx-auto max-w-7xl overflow-hidden py-20 px-6 sm:py-24 lg:px-8">
-    <nav class="-mb-6 columns-2 sm:flex sm:justify-center sm:space-x-12" aria-label="Footer">
+    <nav
+      class="-mb-6 columns-2 sm:flex sm:justify-center sm:space-x-12"
+      aria-label="Footer"
+    >
       <div class="pb-6">
-        <a href="/" class="text-sm leading-6 text-gray-600 hover:text-gray-200">Home</a>
+        <a href="/" class="text-sm leading-6 text-gray-600 hover:text-gray-200"
+          >Home</a
+        >
       </div>
       <div class="pb-6">
-        <a href="/#services" class="text-sm leading-6 text-gray-600 hover:text-gray-200">Services</a>
+        <a
+          href="/#services"
+          class="text-sm leading-6 text-gray-600 hover:text-gray-200"
+          >Services</a
+        >
       </div>
       <div class="pb-6">
-        <a href="/#blog" class="text-sm leading-6 text-gray-600 hover:text-gray-200">Blog</a>
+        <a
+          href="/#blog"
+          class="text-sm leading-6 text-gray-600 hover:text-gray-200"
+          >Blog</a
+        >
       </div>
       <div class="pb-6">
-        <a href="/#contact" class="text-sm leading-6 text-gray-600 hover:text-gray-200">Contact</a>
+        <a
+          href="/#contact"
+          class="text-sm leading-6 text-gray-600 hover:text-gray-200"
+          >Contact</a
+        >
       </div>
       <div class="pb-6">
-        <a href="/privacy-policy/" class="text-sm leading-6 text-gray-600 hover:text-gray-200">Privacy</a>
+        <a
+          href="/privacy-policy/"
+          class="text-sm leading-6 text-gray-600 hover:text-gray-200"
+          >Privacy</a
+        >
       </div>
     </nav>
     <div class="mt-10 flex justify-center space-x-10">
       <!-- LinkedIn -->
-      <a href="https://www.linkedin.com/company/codemanufacture" class="text-gray-400 hover:text-gray-500" target="_blank" rel="noopener noreferrer">
+      <a
+        href="https://www.linkedin.com/company/codemanufacture"
+        class="text-gray-400 hover:text-gray-500"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
         <span class="sr-only">LinkedIn</span>
-        <svg class="h-6 w-6" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-          <path d="M18.335 18.339H15.67v-4.177c0-.996-.02-2.278-1.39-2.278-1.389 0-1.601 1.084-1.601 2.205v4.25h-2.666V9.75h2.56v1.17h.035c.358-.674 1.228-1.387 2.528-1.387 2.7 0 3.2 1.778 3.2 4.091v4.715zM7.003 8.575a1.546 1.546 0 01-1.548-1.549 1.548 1.548 0 111.547 1.549zm1.336 9.764H5.666V9.75H8.34v8.589zM19.67 3H4.329C3.593 3 3 3.58 3 4.297v15.406C3 20.42 3.594 21 4.328 21h15.338C20.4 21 21 20.42 21 19.703V4.297C21 3.58 20.4 3 19.666 3h.003z" />
+        <svg
+          class="h-6 w-6"
+          fill="currentColor"
+          viewBox="0 0 24 24"
+          aria-hidden="true"
+        >
+          <path
+            d="M18.335 18.339H15.67v-4.177c0-.996-.02-2.278-1.39-2.278-1.389 0-1.601 1.084-1.601 2.205v4.25h-2.666V9.75h2.56v1.17h.035c.358-.674 1.228-1.387 2.528-1.387 2.7 0 3.2 1.778 3.2 4.091v4.715zM7.003 8.575a1.546 1.546 0 01-1.548-1.549 1.548 1.548 0 111.547 1.549zm1.336 9.764H5.666V9.75H8.34v8.589zM19.67 3H4.329C3.593 3 3 3.58 3 4.297v15.406C3 20.42 3.594 21 4.328 21h15.338C20.4 21 21 20.42 21 19.703V4.297C21 3.58 20.4 3 19.666 3h.003z"
+          />
         </svg>
       </a>
       <!-- Twitter -->
-      <a href="https://twitter.com/codemanufacture" class="text-gray-400 hover:text-gray-500" target="_blank" rel="noopener noreferrer">
+      <a
+        href="https://twitter.com/codemanufacture"
+        class="text-gray-400 hover:text-gray-500"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
         <span class="sr-only">Twitter</span>
-        <svg class="h-6 w-6" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-          <path d="M8.29 20.251c7.547 0 11.675-6.253 11.675-11.675 0-.178 0-.355-.012-.53A8.348 8.348 0 0022 5.92a8.19 8.19 0 01-2.357.646 4.118 4.118 0 001.804-2.27 8.224 8.224 0 01-2.605.996 4.107 4.107 0 00-6.993 3.743 11.65 11.65 0 01-8.457-4.287 4.106 4.106 0 001.27 5.477A4.072 4.072 0 012.8 9.713v.052a4.105 4.105 0 003.292 4.022 4.095 4.095 0 01-1.853.07 4.108 4.108 0 003.834 2.85A8.233 8.233 0 012 18.407a11.616 11.616 0 006.29 1.84" />
+        <svg
+          class="h-6 w-6"
+          fill="currentColor"
+          viewBox="0 0 24 24"
+          aria-hidden="true"
+        >
+          <path
+            d="M8.29 20.251c7.547 0 11.675-6.253 11.675-11.675 0-.178 0-.355-.012-.53A8.348 8.348 0 0022 5.92a8.19 8.19 0 01-2.357.646 4.118 4.118 0 001.804-2.27 8.224 8.224 0 01-2.605.996 4.107 4.107 0 00-6.993 3.743 11.65 11.65 0 01-8.457-4.287 4.106 4.106 0 001.27 5.477A4.072 4.072 0 012.8 9.713v.052a4.105 4.105 0 003.292 4.022 4.095 4.095 0 01-1.853.07 4.108 4.108 0 003.834 2.85A8.233 8.233 0 012 18.407a11.616 11.616 0 006.29 1.84"
+          />
         </svg>
       </a>
       <!-- GitHub -->
-      <a href="https://github.com/codemanufacture" class="text-gray-400 hover:text-gray-500" target="_blank" rel="noopener noreferrer">
+      <a
+        href="https://github.com/codemanufacture"
+        class="text-gray-400 hover:text-gray-500"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
         <span class="sr-only">GitHub</span>
-        <svg class="h-6 w-6" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-          <path fill-rule="evenodd" d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" clip-rule="evenodd" />
+        <svg
+          class="h-6 w-6"
+          fill="currentColor"
+          viewBox="0 0 24 24"
+          aria-hidden="true"
+        >
+          <path
+            fill-rule="evenodd"
+            d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z"
+            clip-rule="evenodd"
+          />
         </svg>
       </a>
     </div>
     <p class="mt-10 text-center text-xs leading-5 text-gray-500">
-      &copy; {{ now.Year }} Codemanufacture SRLS. All rights reserved. Partita iva: 12607110967
+      &copy; {{ now.Year }} Codemanufacture SRLS. All rights reserved. Partita
+      iva: 12607110967
     </p>
   </div>
 </footer>

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -1,31 +1,49 @@
-<meta charset="utf-8">
-<meta name="viewport" content="width=device-width, initial-scale=1">
-<title>{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ .Title }} | {{ .Site.Title }}{{ end }}</title>
-<meta name="description" content="{{ with .Description }}{{ . }}{{ else }}{{ .Site.Params.description }}{{ end }}">
-<meta name="keywords" content="{{ .Site.Params.keywords }}">
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>
+  {{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ .Title }} | {{ .Site.Title }}{{
+  end }}
+</title>
+<meta
+  name="description"
+  content="{{ with .Description }}{{ . }}{{ else }}{{ .Site.Params.description }}{{ end }}"
+/>
+<meta name="keywords" content="{{ .Site.Params.keywords }}" />
 
 <!-- Open Graph -->
-<meta property="og:title" content="{{ .Title }}">
-<meta property="og:description" content="{{ with .Description }}{{ . }}{{ else }}{{ .Site.Params.description }}{{ end }}">
-<meta property="og:url" content="{{ .Permalink }}">
-<meta property="og:locale" content="en_GB">
-<meta property="og:type" content="{{ if .IsPage }}article{{ else }}website{{ end }}">
-<meta property="og:site_name" content="{{ .Site.Title }}">
+<meta property="og:title" content="{{ .Title }}" />
+<meta
+  property="og:description"
+  content="{{ with .Description }}{{ . }}{{ else }}{{ .Site.Params.description }}{{ end }}"
+/>
+<meta property="og:url" content="{{ .Permalink }}" />
+<meta property="og:locale" content="en_GB" />
+<meta
+  property="og:type"
+  content="{{ if .IsPage }}article{{ else }}website{{ end }}"
+/>
+<meta property="og:site_name" content="{{ .Site.Title }}" />
 
 <!-- Canonical URL -->
-<link rel="canonical" href="{{ .Permalink }}">
+<link rel="canonical" href="{{ .Permalink }}" />
 
 <!-- Favicon -->
-<link rel="icon" type="image/x-icon" href="/favicon.ico">
+<link rel="icon" type="image/x-icon" href="/favicon.ico" />
 
 <!-- Montserrat Font -->
-<link rel="preconnect" href="https://fonts.googleapis.com">
-<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&display=swap" rel="stylesheet">
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link
+  href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&display=swap"
+  rel="stylesheet"
+/>
 
 <!-- Tailwind CSS (pre-built by npm run build:css) -->
-{{ $css := resources.Get "css/output.css" }}
-{{ if $css }}
-  {{ $css = $css | minify | fingerprint }}
-  <link rel="stylesheet" href="{{ $css.Permalink }}" integrity="{{ $css.Data.Integrity }}">
+{{ $css := resources.Get "css/output.css" }} {{ if $css }} {{ $css = $css |
+minify | fingerprint }}
+<link
+  rel="stylesheet"
+  href="{{ $css.Permalink }}"
+  integrity="{{ $css.Data.Integrity }}"
+/>
 {{ end }}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,23 +1,60 @@
-<header class="relative bg-white sticky top-0 z-30 w-full border-b-2 border-gray-100">
+<header
+  class="relative bg-white sticky top-0 z-30 w-full border-b-2 border-gray-100"
+>
   <div class="mx-auto max-w-7xl px-6">
-    <div class="flex items-center justify-between p-6 md:justify-center md:space-x-10">
+    <div
+      class="flex items-center justify-between p-6 md:justify-center md:space-x-10"
+    >
       <!-- Logo -->
       <div class="flex justify-start md:w-0 md:flex-1">
         <a href="/">
           <span class="sr-only">Codemanufacture</span>
-          <img class="h-4 w-auto sm:h-6" src="/images/logo.svg" alt="Codemanufacture">
+          <img
+            class="h-4 w-auto sm:h-6"
+            src="/images/logo.svg"
+            alt="Codemanufacture"
+          />
         </a>
       </div>
 
       <!-- Mobile menu button -->
       <div class="-my-2 -mr-2 md:hidden">
-        <button type="button" id="mobile-menu-button" class="inline-flex items-center justify-center rounded-md bg-white p-2 text-gray-400 hover:bg-gray-100 hover:text-gray-500 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-indigo-500" aria-expanded="false">
+        <button
+          type="button"
+          id="mobile-menu-button"
+          class="inline-flex items-center justify-center rounded-md bg-white p-2 text-gray-400 hover:bg-gray-100 hover:text-gray-500 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-indigo-500"
+          aria-expanded="false"
+        >
           <span class="sr-only">Open menu</span>
-          <svg class="h-6 w-6" id="menu-icon-open" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
-            <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5" />
+          <svg
+            class="h-6 w-6"
+            id="menu-icon-open"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke-width="1.5"
+            stroke="currentColor"
+            aria-hidden="true"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5"
+            />
           </svg>
-          <svg class="hidden h-6 w-6" id="menu-icon-close" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
-            <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+          <svg
+            class="hidden h-6 w-6"
+            id="menu-icon-close"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke-width="1.5"
+            stroke="currentColor"
+            aria-hidden="true"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              d="M6 18L18 6M6 6l12 12"
+            />
           </svg>
         </button>
       </div>
@@ -25,38 +62,94 @@
       <!-- Desktop Navigation -->
       <div class="hidden md:flex md:items-start md:justify-center">
         <nav class="hidden space-x-10 md:flex">
-          <a href="/" class="text-base font-medium text-gray-500 hover:text-gray-900">Home</a>
-          <a href="/#services" class="text-base font-medium text-gray-500 hover:text-gray-900">Services</a>
-          <a href="/#blog" class="text-base font-medium text-gray-500 hover:text-gray-900">Blog</a>
-          <a href="/#contact" class="text-base font-medium text-gray-500 hover:text-gray-900">Contact</a>
+          <a
+            href="/"
+            class="text-base font-medium text-gray-500 hover:text-gray-900"
+            >Home</a
+          >
+          <a
+            href="/#services"
+            class="text-base font-medium text-gray-500 hover:text-gray-900"
+            >Services</a
+          >
+          <a
+            href="/#blog"
+            class="text-base font-medium text-gray-500 hover:text-gray-900"
+            >Blog</a
+          >
+          <a
+            href="/#contact"
+            class="text-base font-medium text-gray-500 hover:text-gray-900"
+            >Contact</a
+          >
         </nav>
       </div>
     </div>
   </div>
 
   <!-- Mobile menu panel -->
-  <div class="absolute inset-x-0 top-0 origin-top-right transform p-2 transition md:hidden z-20 hidden" id="mobile-menu">
-    <div class="divide-y-2 divide-gray-50 rounded-lg bg-white shadow-lg ring-1 ring-black ring-opacity-5">
+  <div
+    class="absolute inset-x-0 top-0 origin-top-right transform p-2 transition md:hidden z-20 hidden"
+    id="mobile-menu"
+  >
+    <div
+      class="divide-y-2 divide-gray-50 rounded-lg bg-white shadow-lg ring-1 ring-black ring-opacity-5"
+    >
       <div class="px-5 pt-5 pb-6">
         <div class="flex items-center justify-between">
           <div>
-            <img class="h-6 w-auto" src="/images/logo.svg" alt="Codemanufacture">
+            <img
+              class="h-6 w-auto"
+              src="/images/logo.svg"
+              alt="Codemanufacture"
+            />
           </div>
           <div class="-mr-2">
-            <button type="button" id="mobile-menu-close" class="inline-flex items-center justify-center rounded-md bg-white p-2 text-gray-400 hover:bg-gray-100 hover:text-gray-500 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-indigo-500">
+            <button
+              type="button"
+              id="mobile-menu-close"
+              class="inline-flex items-center justify-center rounded-md bg-white p-2 text-gray-400 hover:bg-gray-100 hover:text-gray-500 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-indigo-500"
+            >
               <span class="sr-only">Close menu</span>
-              <svg class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
-                <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+              <svg
+                class="h-6 w-6"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke-width="1.5"
+                stroke="currentColor"
+                aria-hidden="true"
+              >
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  d="M6 18L18 6M6 6l12 12"
+                />
               </svg>
             </button>
           </div>
         </div>
         <div class="mt-6">
           <nav class="grid gap-y-8">
-            <a href="/" class="text-base font-medium text-gray-500 hover:text-gray-900">Home</a>
-            <a href="/#services" class="text-base font-medium text-gray-500 hover:text-gray-900">Services</a>
-            <a href="/#blog" class="text-base font-medium text-gray-500 hover:text-gray-900">Blog</a>
-            <a href="/#contact" class="text-base font-medium text-gray-500 hover:text-gray-900">Contact</a>
+            <a
+              href="/"
+              class="text-base font-medium text-gray-500 hover:text-gray-900"
+              >Home</a
+            >
+            <a
+              href="/#services"
+              class="text-base font-medium text-gray-500 hover:text-gray-900"
+              >Services</a
+            >
+            <a
+              href="/#blog"
+              class="text-base font-medium text-gray-500 hover:text-gray-900"
+              >Blog</a
+            >
+            <a
+              href="/#contact"
+              class="text-base font-medium text-gray-500 hover:text-gray-900"
+              >Contact</a
+            >
           </nav>
         </div>
       </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
       "devDependencies": {
         "@tailwindcss/cli": "^4.0.0",
         "@tailwindcss/typography": "^0.5.19",
-        "prettier": "3.7.4",
         "tailwindcss": "^4.0.0"
       }
     },
@@ -1123,22 +1122,6 @@
       },
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/prettier": {
-      "version": "3.7.4",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.7.4.tgz",
-      "integrity": "sha512-v6UNi1+3hSlVvv8fSaoUbggEM5VErKmmpGA7Pl3HF8V6uKY7rvClBOJlH6yNwQtfTueNkGVpOv/mtWL9L4bgRA==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "prettier": "bin/prettier.cjs"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/source-map-js": {

--- a/package.json
+++ b/package.json
@@ -8,14 +8,11 @@
   "license": "Apache-2.0",
   "scripts": {
     "build:css": "tailwindcss -i ./assets/css/main.css -o ./assets/css/output.css --minify",
-    "watch:css": "tailwindcss -i ./assets/css/main.css -o ./assets/css/output.css --watch",
-    "format:markdown": "prettier --config .prettierrc --parser markdown --write '{content/**/*.md,README.md}'",
-    "nit:markdown": "prettier --config .prettierrc --parser markdown --list-different '{content/**/*.md,README.md}'"
+    "watch:css": "tailwindcss -i ./assets/css/main.css -o ./assets/css/output.css --watch"
   },
   "devDependencies": {
     "@tailwindcss/cli": "^4.0.0",
     "@tailwindcss/typography": "^0.5.19",
-    "prettier": "3.7.4",
     "tailwindcss": "^4.0.0"
   }
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,9 +1,5 @@
 {
-  "extends": [
-    "config:base",
-    "docker:disable",
-    "schedule:nonOfficeHours"
-  ],
+  "extends": ["config:base", "docker:disable", "schedule:nonOfficeHours"],
   "automerge": true,
   "major": {
     "automerge": false


### PR DESCRIPTION
## Summary

- Move prettier configuration from `.prettierrc` to `flake.nix` treefmt
- Add `prettier-plugin-go-template` for Hugo template formatting
- Remove prettier from `package.json` devDependencies
- Delete `.prettierrc` and `.prettierignore` files
- Add CI workflow to check formatting on pull requests only
- Fix nested quotes in Hugo templates for go-template parser compatibility

## Test plan

- [ ] Verify `nix fmt` runs successfully
- [ ] Verify `nix fmt -- --fail-on-change` passes (no unformatted files)
- [ ] Verify Hugo site builds correctly
- [ ] Verify format-check CI workflow runs on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)